### PR TITLE
lv-10-social-media-icons

### DIFF
--- a/components/ui/Navbar.tsx
+++ b/components/ui/Navbar.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import clsx from "clsx";
 import Image from "next/image";
+import { FaInstagram, FaEnvelope } from "react-icons/fa";
+import { FaE } from "react-icons/fa6";
 
 const navLinks = [
     { name: "Home", href: "/" },
@@ -47,8 +49,18 @@ export default function Navbar() {
                     </div>
                 </div>
                 <div className="flex flex-row space-x-4">
-                    <div>instagram</div>
-                    <div>email</div>
+                    <a
+                    href="https://instagram.com/_lovevisuals_"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >
+                        <FaInstagram className="w-10 h-10" />
+                    </a>
+                    <a
+                    href="mailto:your email@example.com"
+                    >
+                        <FaEnvelope className="w-10 h-10" />
+                    </a>
                 </div>
             </div>
         </nav>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "lenis": "^1.3.21",
         "next": "^16.2.3",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "react-icons": "^5.6.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -5598,6 +5599,15 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lenis": "^1.3.21",
     "next": "^16.2.3",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "react-icons": "^5.6.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
closes #10 

## Context

Needed social media icons instead of the placeholder names

## What Changed?

- Added `react-icons` as a package
- Added social media icons to the navbar

## How To Review

- Only one file/component changed

## Testing

UI Testing

## Risks

None

## Notes
