### PR TITLE
lv-2-responsive-card-image-component

### DIFF
--- a/app/(website)/about/page.tsx
+++ b/app/(website)/about/page.tsx
@@ -1,13 +1,12 @@
 import CardImage from "@/components/home/CardImage"
 
 
-
 export default function About() {
     return (
             <div className="bg-[linear-gradient(to_bottom,#678BAA,#EBE8D8)] relative min-h-screen w-full flex flex-col items-center justify-center gap-8 bg-gray-500">
                 <div className="flex flex-row w-full items-center justify-start gap-4 px-60">
                     <div className="w-full">
-                        <CardImage src="/img.jpg" alt="" width={500} height={430} />
+                        <CardImage src="/img.jpg" alt="" className="w-40 h-60 md:w-126 md:h-116" />
                     </div>
                     <div className="flex flex-col">
                         <div className="flex items-center justify-center h-full whitespace-nowrap text-9xl">
@@ -19,10 +18,10 @@ export default function About() {
                     </div>
                 </div>
                 <div className="flex flex-row gap-4">
-                    <CardImage src="/img.jpg" alt="" width={400} height={300} />
-                    <CardImage src="/img.jpg" alt="" width={400} height={300} />
-                    <CardImage src="/img.jpg" alt="" width={400} height={300} />
-                    <CardImage src="/img.jpg" alt="" width={400} height={300} />
+                    <CardImage src="/img.jpg" alt="" className="w-40 h-60 md:w-100 md:h-76" />
+                    <CardImage src="/img.jpg" alt="" className="w-40 h-60 md:w-100 md:h-76" />
+                    <CardImage src="/img.jpg" alt="" className="w-40 h-60 md:w-100 md:h-76" />
+                    <CardImage src="/img.jpg" alt="" className="w-40 h-60 md:w-100 md:h-76" />
                 </div>
             </div>
     );

--- a/app/(website)/page.tsx
+++ b/app/(website)/page.tsx
@@ -24,13 +24,14 @@ export default function Landing() {
                     />
                 </div>
             </div>
+            
             <div className="bg-[linear-gradient(to_bottom,#678BAA,#EBE8D8)] flex flex-col items-center justify-center min-h-screen">
                 <div className="flex items-center gap-4">
-                    <CardImage src="/img.jpg" alt="" width={300} height={550} />
-                    <CardImage src="/img.jpg" alt="" width={300} height={700} />
-                    <CardImage src="/img.jpg" alt="" width={300} height={550} />
-                    <CardImage src="/img.jpg" alt="" width={300} height={700} />
-                    <CardImage src="/img.jpg" alt="" width={300} height={550} />
+                    <CardImage src="/img.jpg" alt="" className="w-50 h-60 md:w-75 md:h-138" />
+                    <CardImage src="/img.jpg" alt="" className="w-40 h-60 md:w-75 md:h-174" />
+                    <CardImage src="/img.jpg" alt="" className="w-40 h-60 md:w-75 md:h-138" />
+                    <CardImage src="/img.jpg" alt="" className="w-40 h-60 md:w-75 md:h-174" />
+                    <CardImage src="/img.jpg" alt="" className="w-40 h-60 md:w-75 md:h-138" />
                 </div>
                 <div className="flex flex-col items-center">
                     <h1 className="text-4xl font-bold text-center mt-8 tracking-wider">
@@ -46,15 +47,15 @@ export default function Landing() {
 
             <div className="bg-[#EBE8D8] min-h-screen flex flex-col items-center justify-center p-4">
                 <div className="grid grid-cols-3 gap-8">
-                    <CardImage src="/img.jpg" alt="Image 1" width={500} height={350} />
-                    <CardImage src="/img.jpg" alt="Image 1" width={500} height={350} />
-                    <CardImage src="/img.jpg" alt="Image 1" width={500} height={350} />
-                    <CardImage src="/img.jpg" alt="Image 1" width={500} height={350} />
-                    <CardImage src="/img.jpg" alt="Image 1" width={500} height={350} />
-                    <CardImage src="/img.jpg" alt="Image 1" width={500} height={350} />
-                    <CardImage src="/img.jpg" alt="Image 1" width={500} height={350} />
-                    <CardImage src="/img.jpg" alt="Image 1" width={500} height={350} />
-                    <CardImage src="/img.jpg" alt="Image 1" width={500} height={350} />
+                    <CardImage src="/img.jpg" alt="Image 1" className="w-40 h-60 md:w-126 md:h-88" />
+                    <CardImage src="/img.jpg" alt="Image 1" className="w-40 h-60 md:w-126 md:h-88" />
+                    <CardImage src="/img.jpg" alt="Image 1" className="w-40 h-60 md:w-126 md:h-88" />
+                    <CardImage src="/img.jpg" alt="Image 1" className="w-40 h-60 md:w-126 md:h-88" />
+                    <CardImage src="/img.jpg" alt="Image 1" className="w-40 h-60 md:w-126 md:h-88" />
+                    <CardImage src="/img.jpg" alt="Image 1" className="w-40 h-60 md:w-126 md:h-88" />
+                    <CardImage src="/img.jpg" alt="Image 1" className="w-40 h-60 md:w-126 md:h-88" />
+                    <CardImage src="/img.jpg" alt="Image 1" className="w-40 h-60 md:w-126 md:h-88" />
+                    <CardImage src="/img.jpg" alt="Image 1" className="w-40 h-60 md:w-126 md:h-88" />
                 </div>
                 <Link href="/portfolio">
                     <button className="mt-6 px-6 py-3 bg-white text-black rounded-sm text-lg" >

--- a/app/(website)/portfolio/page.tsx
+++ b/app/(website)/portfolio/page.tsx
@@ -6,7 +6,7 @@ export default function Portfolio() {
     return (
             <div className="bg-[linear-gradient(to_bottom,#678BAA,#EBE8D8)] relative min-h-screen w-full flex flex-row items-center justify-center gap-8 bg-gray-500">
                 <div className="relative">
-                    <CardImage src="/img.jpg" alt="" width={600} height={800} />
+                    <CardImage src="/img.jpg" alt="" className="w-40 h-60 md:w-140 md:h-200"/>
                     <div>
                         <h1 className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-white text-8xl">
                             images
@@ -14,7 +14,7 @@ export default function Portfolio() {
                     </div>
                 </div>
                 <div className="relative">
-                    <CardImage src="/img.jpg" alt="" width={600} height={800} />
+                    <CardImage src="/img.jpg" alt="" className="w-40 h-60 md:w-140 md:h-200"/>
                     <div>
                         <h1 className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-white text-8xl">
                             videos

--- a/components/home/CardImage.tsx
+++ b/components/home/CardImage.tsx
@@ -3,22 +3,17 @@ import Image from "next/image";
 interface CardImageProps {
     src: string;
     alt: string;
-    width: number;
-    height: number;
+    className?: string;
 }
 
-export default function CardImage({ src, alt, width, height }: CardImageProps) {
+export default function CardImage({ src, alt, className }: CardImageProps) {
     return (
-        <div
-            style={{ width: `${width}px`, height: `${height}px`, overflow: "hidden" }}
-            className="rounded-lg"
-        >
+        <div className={`relative overflow-hidden rounded-lg ${className}`}>
             <Image
-            src={src}
-            width={width}
-            height={height}
-            className="object-cover w-full h-full"
-            alt={alt}
+                src={src}
+                fill
+                className="object-cover"
+                alt={alt}
             />
         </div>
     );

--- a/components/ui/Navbar.tsx
+++ b/components/ui/Navbar.tsx
@@ -5,7 +5,6 @@ import { usePathname } from "next/navigation";
 import clsx from "clsx";
 import Image from "next/image";
 import { FaInstagram, FaEnvelope } from "react-icons/fa";
-import { FaE } from "react-icons/fa6";
 
 const navLinks = [
     { name: "Home", href: "/" },


### PR DESCRIPTION
closes #2 

## Context

- `CardImage` component was not responsive, it was only allowed to use one fixed size due to the current implementation using inline styling meaning tailwind breakpoints would be overridden

## What Changed?

- Changed the `CardImage` to accept a `className` instead of fixed `height` and `width` values, allowing breakpoint usage

## How To Review

<!-- What (rough) order should the reviewer view your files? -->

- `CardImage.tsx` component
- `page.tsx` in `/(website)`, `/about` and `/portfolio`

## Testing

- Manual UI testing

## Risks

None

## Notes
